### PR TITLE
Fixing random crashes during "dict" commands due to buffer size miscalculation

### DIFF
--- a/models.txt
+++ b/models.txt
@@ -10,6 +10,7 @@ Dataplus 3 EW-H6000      gy131,ON,0101   gy331                     07cf:6101
 Dataplus 3 XD-SW4800     gy131,ON,0101   gy350                     07cf:6101
 Dataplus 3 XD-SW9400     gy131,ON,0101   gy352                     07cf:6101
 Dataplus 3 XD-SW6400     gy131,ON,0101   gy355                     07cf:6101
+Dataplus 3 XD-SW6500     gy131,ON,0200   gy356                     07cf:6101
 Dataplus 3 XD-GW9600     gy131,ON,0101   gy392                     07cf:6101
 Dataplus 4 EV-SP2900     gy131,ON,0100   gy808                     07cf:6101
 Dataplus 4 EV-SP3900     gy131,ON,0100   gy809                     07cf:6101

--- a/src/exword.c
+++ b/src/exword.c
@@ -19,7 +19,6 @@
  *
  */
 
-#include <arpa/inet.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/exword.c
+++ b/src/exword.c
@@ -19,6 +19,12 @@
  *
  */
 
+#if defined(__MINGW32__)
+# include <WinSock2.h>
+#else
+# include <arpa/inet.h>
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/list.h
+++ b/src/list.h
@@ -187,7 +187,7 @@ static inline void list_splice_init(struct list_head *list,
  * @member:	the name of the list_struct within the struct.
  */
 #define list_entry(ptr, type, member) \
-	((type *)((char *)(ptr)-(unsigned long)(&((type *)0)->member)))
+	((type *)((void *)(ptr)-offsetof(type, member)))
 
 /**
  * list_for_each	-	iterate over a list

--- a/src/list.h
+++ b/src/list.h
@@ -1,6 +1,8 @@
 #ifndef __LIST_H
 #define __LIST_H
 
+#include <stddef.h>
+
 /* This file is from Linux Kernel (include/linux/list.h) 
  * and modified by simply removing hardware prefetching of list items. 
  * Here by copyright, credits attributed to wherever they belong.

--- a/src/main.c
+++ b/src/main.c
@@ -535,7 +535,14 @@ void content(struct state *s)
 				int rsp = exword_get_file(s->device, "user.inf", &buffer, &len);
 				if (rsp == EXWORD_SUCCESS) {
 					user = xmalloc(len+1);
-					sscanf(buffer, "%s\n", user);
+					for (int i = 0; i < len; i++) {
+						user[i + 1] = 0;
+						if (buffer[i] > ' ') {
+							user[i] = buffer[i];
+						} else {
+							break;
+						}
+					}
 					free(buffer);
 				} else {
 					printf("No username specified.\n");

--- a/src/main.c
+++ b/src/main.c
@@ -507,7 +507,7 @@ void content(struct state *s)
 	if (peek_arg(&(s->cmd_list)) == NULL) {
 		printf("No sub-function specified.\n");
 	} else {
-		subfunc = xmalloc(strlen(peek_arg(&(s->cmd_list)) + 1));
+		subfunc = xmalloc(strlen(peek_arg(&(s->cmd_list))) + 1);
 		strcpy(subfunc, peek_arg(&(s->cmd_list)));
 		dequeue_arg(&(s->cmd_list));
 		if (strcmp(subfunc, "list") == 0) {
@@ -541,7 +541,7 @@ void content(struct state *s)
 					printf("No username specified.\n");
 				}
 			} else {
-				user = xmalloc(strlen(peek_arg(&(s->cmd_list)) + 1));
+				user = xmalloc(strlen(peek_arg(&(s->cmd_list))) + 1);
 				strcpy(user, peek_arg(&(s->cmd_list)));
 				dequeue_arg(&(s->cmd_list));
 			}

--- a/src/obex.c
+++ b/src/obex.c
@@ -24,7 +24,6 @@
  *
  */
 
-#include <arpa/inet.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/obex.c
+++ b/src/obex.c
@@ -24,6 +24,12 @@
  *
  */
 
+#if defined(__MINGW32__)
+# include <Winsock2.h>
+#else
+# include <arpa/inet.h>
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/util.h
+++ b/src/util.h
@@ -23,6 +23,7 @@
 #define _UTIL_H
 
 #if defined(__MINGW32__)
+# include <direct.h>
 # define mkdir(path, mode) _mkdir(path)
 # define PATH_SEP "\\"
 #else


### PR DESCRIPTION
I believe there are two places where buffer sizes are miscalculated in main.c, where they should be "strlen(str) + 1" but a misplaced parenthesis makes this "strlen(str + 1)" which results in a buffer two bytes too small. On Windows at least this means the program will randomly crash when performing "dict" commands, and gdb consistently reports "Heap block at x modified at y past requested size of n" when using the "dict" commands.

(I also had to make some minor other tweaks to get the program building without errors and warnings, but these should not affect other platforms).